### PR TITLE
Python 3 compatibility

### DIFF
--- a/dmgbuild/core.py
+++ b/dmgbuild/core.py
@@ -479,7 +479,7 @@ def build_dmg(filename, volume_name, settings_file=None, settings={},
                         try:
                             subprocess.check_call(
                                 ['/usr/bin/tiffutil', '-cathidpicheck'] +
-                                filter(None, orderedImages) +
+                                list(filter(None, orderedImages)) +
                                 ['-out', background], stdout=output, stderr=output)
                         except Exception as e:
                             output.seek(0)


### PR DESCRIPTION
Fix error when using Python 3: `TypeError: can only concatenate list (not "filter") to list`