### PR TITLE
Downgrade tested Python version to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ matrix:
       env: PYTHON_VERSION=3.6.2
     - os: osx
       language: generic
-      env: PYTHON_VERSION=2.7.13
+      env: PYTHON_VERSION=2.7.0
 
 script: python setup.py test


### PR DESCRIPTION
This will help ensure that the build doesn't break on older macOS
versions.