### PR TITLE
Test only relevant system Python versions for macOS's since 10.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,15 @@ matrix:
       env: PYTHON_VERSION=3.6.2
     - os: osx
       language: generic
-      env: PYTHON_VERSION=2.7.0
+      env: PYTHON_VERSION=2.7.10
+    - os: osx
+      language: generic
+      env: PYTHON_VERSION=2.7.5
+    - os: osx
+      language: generic
+      env: PYTHON_VERSION=2.7.2
+    - os: osx
+      language: generic
+      env: PYTHON_VERSION=2.7.1
 
 script: python setup.py test


### PR DESCRIPTION
Test only relevant system Python versions for macOS's since 10.7. This
helps to uncover any issues that are version-specific.