### PR TITLE
Fix RTF license when input data is a file path

### DIFF
--- a/dmgbuild/licensing.py
+++ b/dmgbuild/licensing.py
@@ -428,7 +428,8 @@ def add_license(filename, license_info):
         is_two_byte = lang_id in (14, 51, 52, 53) # Japanese, Korean, SimpChinese, TradChinese
 
         if os.path.isfile(license_data):
-            with open(license_data) as f:
+            mode = 'rb' if license_data.endswith('.rtf') else 'r'
+            with open(license_data, mode=mode) as f:
                 license_data = f.read()
 
         if type(license_data) == bytes and license_data.startswith(b'{\\rtf1'):


### PR DESCRIPTION
Hello!

Currently, when we attempt to create a DMG using a RTF license provided as a **file path**, the resource that is created is a plain-text one rather than a RTF resource. The result is that the RTF underlying file data is printed verbatim in the final text-box rather than printed as rich text.

This behavior comes from [this condition](https://github.com/al45tair/dmgbuild/blob/master/dmgbuild/licensing.py#L434). In our RTF **file path** case, it will always be `false` because the type of `license_data` will always be `str` as [it is always opened in text mode](https://github.com/al45tair/dmgbuild/blob/master/dmgbuild/licensing.py#L431), and therefore the data will always be interpreted as plain-text rather than RTF.

This pull request aims to fix this by opening the file in **binary** if its path ends with `.rtf`. Because the actual condition was not changed, I believe this should not impact users who directly provided the binary file data as input.