### PR TITLE
Note that badge icons require Quartz.

### DIFF
--- a/doc/settings.rst
+++ b/doc/settings.rst
@@ -104,6 +104,8 @@ Content Settings
 
      badge_icon = '/Applications/TextEdit.app/Contents/Resources/Edit.icns'
 
+   Badge icons require pyobjc-framework-Quartz.
+
 .. py:data:: icon_locations
 
    A dictionary specifying the co-ordinates of items in the root

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -57,7 +57,8 @@ symlinks = { 'Applications': '/Applications' }
 #
 # You can either define icon, in which case that icon file will be copied to the
 # image, *or* you can define badge_icon, in which case the icon file you specify
-# will be used to badge the system's Removable Disk icon
+# will be used to badge the system's Removable Disk icon. Badge icons require
+# pyobjc-framework-Quartz.
 #
 #icon = '/path/to/icon.icns'
 badge_icon = icon_from_app(application)


### PR DESCRIPTION
Add a note about pyobjc-framework-Quartz to the settings example and
documentation.