### PR TITLE
change total_size calculation to base 10

### DIFF
--- a/dmgbuild/core.py
+++ b/dmgbuild/core.py
@@ -378,7 +378,7 @@ def build_dmg(filename, volume_name, settings_file=None, settings={},
         # size of the background image, volume icon, and .DS_Store file (and
         # 128 MB should be well sufficient for even the most outlandish image
         # sizes, like an uncompressed 5K multi-resolution TIFF)
-        total_size = 128 * 1024 * 1024
+        total_size = 128e6
 
         def roundup(x, n):
             return x if x % n == 0 else x + n - x % n
@@ -391,12 +391,12 @@ def build_dmg(filename, volume_name, settings_file=None, settings={},
                 for dirpath, dirnames, filenames in os.walk(path):
                     for f in filenames:
                         fp = os.path.join(dirpath, f)
-                        total_size += roundup(os.lstat(fp).st_size, 4096)
+                        total_size += roundup(os.lstat(fp).st_size, 4000)
             else:
-                total_size += roundup(os.lstat(path).st_size, 4096)
+                total_size += roundup(os.lstat(path).st_size, 4000)
 
         for name,target in iteritems(options['symlinks']):
-            total_size += 4096
+            total_size += 4000
 
         total_size = str(max(total_size / 1000, 1000)) + 'K'
 

--- a/dmgbuild/core.py
+++ b/dmgbuild/core.py
@@ -398,7 +398,7 @@ def build_dmg(filename, volume_name, settings_file=None, settings={},
         for name,target in iteritems(options['symlinks']):
             total_size += 4096
 
-        total_size = str(max(total_size / 1024, 1024)) + 'K'
+        total_size = str(max(total_size / 1000, 1000)) + 'K'
 
     ret, output = hdiutil('create',
                           '-ov',

--- a/dmgbuild/core.py
+++ b/dmgbuild/core.py
@@ -391,14 +391,14 @@ def build_dmg(filename, volume_name, settings_file=None, settings={},
                 for dirpath, dirnames, filenames in os.walk(path):
                     for f in filenames:
                         fp = os.path.join(dirpath, f)
-                        total_size += roundup(os.lstat(fp).st_size, 4000)
+                        total_size += roundup(os.lstat(fp).st_size, 4096)
             else:
-                total_size += roundup(os.lstat(path).st_size, 4000)
+                total_size += roundup(os.lstat(path).st_size, 4096)
 
         for name,target in iteritems(options['symlinks']):
-            total_size += 4000
+            total_size += 4096
 
-        total_size = str(max(total_size / 1000, 1000)) + 'K'
+        total_size = str(max(total_size / 1000, 1024)) + 'K'
 
     ret, output = hdiutil('create',
                           '-ov',

--- a/dmgbuild/core.py
+++ b/dmgbuild/core.py
@@ -378,7 +378,7 @@ def build_dmg(filename, volume_name, settings_file=None, settings={},
         # size of the background image, volume icon, and .DS_Store file (and
         # 128 MB should be well sufficient for even the most outlandish image
         # sizes, like an uncompressed 5K multi-resolution TIFF)
-        total_size = 128e6
+        total_size = 128 * 1024 * 1024
 
         def roundup(x, n):
             return x if x % n == 0 else x + n - x % n


### PR DESCRIPTION
In using dmgbuild (via [briefcase](https://github.com/beeware/briefcase)), the auto dmg size calculation has been consistently under calculating (by about 1.5%) on a large (~1.2GB) app bundle for me, leading to failed `hdiutil` command with 
```
  File "briefcase/platforms/macOS/dmg.py", line 126, in package_app
    self.dmgbuild.build_dmg(
  File "dmgbuild/core.py", line 524, in build_dmg
    os.symlink(target, name_in_image)
OSError: [Errno 28] No space left on device: '/Applications' -> '/Volumes/app_bundle/Applications'
```
I tracked it down to this line:
https://github.com/al45tair/dmgbuild/blob/fc1d8014e6c373c0fefc8fe023e73f805e10ead9/dmgbuild/core.py#L401

If all the calculations are done with base-10 instead of base-2 numbers, it works fine.  Perhaps related to [mac's move to base-10 sizing in 10.6](https://support.apple.com/en-us/HT201402)?