### PR TITLE
Allow setting custom detach timeout

### DIFF
--- a/dmgbuild/core.py
+++ b/dmgbuild/core.py
@@ -129,7 +129,7 @@ def load_json(filename, settings):
     settings['icon_locations'] = icon_locations
 
 def build_dmg(filename, volume_name, settings_file=None, settings={},
-              defines={}, lookForHiDPI=True, detach_timeout=5):
+              defines={}, lookForHiDPI=True, detach_retries=5):
     options = {
         # Default settings
         'filename': filename,
@@ -550,7 +550,7 @@ def build_dmg(filename, volume_name, settings_file=None, settings={},
         hdiutil('detach', '-force', device, plist=False)
         raise
 
-    for tries in range(detach_timeout):
+    for tries in range(detach_retries):
         ret, output = hdiutil('detach', device, plist=False)
         if not ret:
             break

--- a/dmgbuild/core.py
+++ b/dmgbuild/core.py
@@ -129,7 +129,7 @@ def load_json(filename, settings):
     settings['icon_locations'] = icon_locations
 
 def build_dmg(filename, volume_name, settings_file=None, settings={},
-              defines={}, lookForHiDPI=True):
+              defines={}, lookForHiDPI=True, detach_timeout=5):
     options = {
         # Default settings
         'filename': filename,
@@ -550,7 +550,7 @@ def build_dmg(filename, volume_name, settings_file=None, settings={},
         hdiutil('detach', '-force', device, plist=False)
         raise
 
-    for tries in range(5):
+    for tries in range(detach_timeout):
         ret, output = hdiutil('detach', device, plist=False)
         if not ret:
             break


### PR DESCRIPTION
Default detach timeout may be not enough in some cases, like antivirus scanning of the new dmg, so its creation fails after force detach of the image. The ability to change the detach timeout/retry count should help in such cases.