### PR TITLE
fix slowdowns when detaching

### DIFF
--- a/dmgbuild/core.py
+++ b/dmgbuild/core.py
@@ -659,6 +659,9 @@ def build_dmg(filename, volume_name, settings_file=None, settings={},
 
     callback({'type': 'operation::finished', 'operation': 'dmg::create'})
 
+    # Flush writes before attempting to detach.
+    subprocess.check_call(('sync', '--file-system', mount_point))
+
     for tries in range(detach_retries):
         callback({'type': 'command::start', 'command': 'hdiutil::detach'})
 


### PR DESCRIPTION
Use `sync` to flush writes before attempting to detach, work around the following errors:
```
hdiutil: detach: timeout for DiskArbitration expired
hdiutil: detach: drive not detached
```

On a project that uses dmgbuild, no more timeouts since [switching to a version of dmgbuild containing this patch](https://github.com/openstenoproject/plover/pull/1266):
* before: the timeout error occurred on 44 of the 119 workflow runs (36.97%)
* after: no occurrence out of the 74 workflow runs